### PR TITLE
Fix atomic_sub on 32-bit ubuntu 1.7

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,11 +12,18 @@ jobs:
         version:
           - '1.5'
           - '^1.6.0-0'
+          - '1'
           - 'nightly'
         os:
           - ubuntu-latest
+          - macOS-latest
+          - windows-latest
         arch:
           - x64
+          - x86
+        exclude:
+          - os: macOS-latest
+            arch: x86
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,19 +11,13 @@ jobs:
       matrix:
         version:
           - '1.5'
-          - '^1.6.0-0'
           - '1'
           - 'nightly'
         os:
           - ubuntu-latest
-          - macOS-latest
-          - windows-latest
         arch:
           - x64
           - x86
-        exclude:
-          - os: macOS-latest
-            arch: x86
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/VersionVigilante.yml
+++ b/.github/workflows/VersionVigilante.yml
@@ -1,0 +1,45 @@
+name: VersionVigilante
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - ".github/**"
+      - "Project.toml"
+      - "README.md"
+      - "dev/**"
+
+jobs:
+  VersionVigilante:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.8.0
+        with:
+          access_token: ${{ github.token }}
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: 1.6
+      - name: VersionVigilante.main
+        id: versionvigilante_main
+        run: |
+          julia -e 'using Pkg; Pkg.add("VersionVigilante")'
+          julia -e 'using VersionVigilante; VersionVigilante.main("https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}")'
+      - name: ✅ Un-Labeller (if success)
+        if: (steps.versionvigilante_main.outputs.compare_versions == 'success') && (success() || failure())
+        continue-on-error: true
+        uses: actions/github-script@0.3.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.removeLabel({...context.issue, name: 'needs version bump'})
+      - name: ❌ Labeller (if failure)
+        if: (steps.versionvigilante_main.outputs.compare_versions == 'failure') && (success() || failure())
+        continue-on-error: true
+        uses: actions/github-script@0.3.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.addLabels({...context.issue, labels: ['needs version bump']})

--- a/.github/workflows/VersionVigilante.yml
+++ b/.github/workflows/VersionVigilante.yml
@@ -26,7 +26,7 @@ jobs:
         id: versionvigilante_main
         run: |
           julia -e 'using Pkg; Pkg.add("VersionVigilante")'
-          julia -e 'using VersionVigilante; VersionVigilante.main("https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}")'
+          julia -e 'using VersionVigilante; VersionVigilante.main("https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}"; master_branch="main")'
       - name: ✅ Un-Labeller (if success)
         if: (steps.versionvigilante_main.outputs.compare_versions == 'success') && (success() || failure())
         continue-on-error: true

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CountDownLatches"
 uuid = "621fb831-fdad-4fff-93ac-1af7b7ed19e3"
 authors = ["Octogonapus <firey45@gmail.com> and contributors"]
-version = "1.0.0"
+version = "1.0.1"
 
 [compat]
 julia = "1.0"

--- a/src/CountDownLatches.jl
+++ b/src/CountDownLatches.jl
@@ -16,7 +16,7 @@ mutable struct CountDownLatch{I<:Integer}
             throw(ArgumentError("Count ($count) must not be negative."))
         end
 
-        new{I}(Threads.Atomic{I}(count), Threads.Condition(ReentrantLock()))
+        new{I}(Threads.Atomic{I}(I(count)), Threads.Condition(ReentrantLock()))
     end
 end
 

--- a/src/CountDownLatches.jl
+++ b/src/CountDownLatches.jl
@@ -8,7 +8,7 @@ export CountDownLatch, await, count_down, get_count
 A `CountDownLatch` that starts at some initial non-negative `count`. This latch can be counted down and waited on.
 """
 mutable struct CountDownLatch{I<:Integer}
-    count::Threads.Atomic{Int64}
+    count::Threads.Atomic{I}
     condition::Threads.Condition
 
     function CountDownLatch(count::I) where {I<:Integer}

--- a/src/CountDownLatches.jl
+++ b/src/CountDownLatches.jl
@@ -7,7 +7,7 @@ export CountDownLatch, await, count_down, get_count
 
 A `CountDownLatch` that starts at some initial non-negative `count`. This latch can be counted down and waited on.
 """
-mutable struct CountDownLatch
+mutable struct CountDownLatch{I<:Integer}
     count::Threads.Atomic{Int64}
     condition::Threads.Condition
 
@@ -16,7 +16,7 @@ mutable struct CountDownLatch
             throw(ArgumentError("Count ($count) must not be negative."))
         end
 
-        new(Threads.Atomic{Int64}(count), Threads.Condition(ReentrantLock()))
+        new{I}(Threads.Atomic{I}(count), Threads.Condition(ReentrantLock()))
     end
 end
 
@@ -44,22 +44,8 @@ end
 Counts down the `latch` once. This may cause the count to become negative. Any tasks that were blocked in `await` will
 be woken if the count becomes `<= 0`.
 """
-function count_down(latch::CountDownLatch)
-    # I think doing something like:
-    #
-    # 1: count = get_count(latch)
-    # 2: count == 0 && return
-    # 3: next_count = count - 1
-    # 4: if Threads.atomic_cas!(latch.count, count, next_count) == count
-    # 5:     lock(latch.condition) do
-    # 6:         notify(latch.condition, nothing; all = true, error = false)
-    # 7:     end
-    # 8: end
-    #
-    # is wrong here because of the case where a thread decrements count after line 1 and before line 4. In that case,
-    # two calls to `notify` must still happen, but only one would.
-
-    Threads.atomic_sub!(latch.count, 1)
+function count_down(latch::CountDownLatch{I}) where {I<:Integer}
+    Threads.atomic_sub!(latch.count, I(1))
     lock(latch.condition) do
         notify(latch.condition, nothing; all = true, error = false)
     end


### PR DESCRIPTION
This PR fixes an issue with calling `atomic_sub!` I just saw on 32-bit Ubuntu Julia v1.7.

```
MethodError: no method matching atomic_sub!(::Base.Threads.Atomic{Int64}, ::Int32)
Closest candidates are:
  atomic_sub!(::Base.Threads.Atomic{Int32}, ::Int32) at /opt/hostedtoolcache/julia/1.7.2/x86/share/julia/base/atomics.jl:405
  atomic_sub!(::Base.Threads.Atomic{Int64}, ::Int64) at /opt/hostedtoolcache/julia/1.7.2/x86/share/julia/base/atomics.jl:405
Stacktrace:
 [1] count_down(latch::CountDownLatch)
   @ CountDownLatches ~/.julia/packages/CountDownLatches/pQusP/src/CountDownLatches.jl:62
```
